### PR TITLE
Enable live API fetching by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,8 @@ Notes
   - CoinCap chart fallback: /v2/assets/bitcoin/history?interval=m15&start=...&end=...
 
 Offline Mode (no API calls)
-- By default, the app now runs in offline/mock mode and does not call any external APIs. Prices and the BTC chart are generated locally via a small random-walk simulation.
-- To enable live APIs, set in `.env.local`:
-  - VITE_ENABLE_API=true
+- The app uses live APIs by default. To run without network access, set in `.env.local`:
+  - VITE_ENABLE_API=false
   - Optionally: VITE_COINGECKO_API_KEY=your_key_here
   - Optional dev-only bypass: VITE_USE_COINCAP_ONLY=true (skip CoinGecko)
   Then restart the dev server.

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,8 +1,8 @@
 import type { CoinId, MarketChartResponse, SimplePriceResponse, TickerData } from '../types';
 
-// Offline-first: disable live APIs by default unless explicitly enabled
+// Enable live APIs by default. Set VITE_ENABLE_API=false to use mock data.
 const DEV = (import.meta as any).env?.DEV as boolean | undefined;
-const ENABLE_API = ((import.meta as any).env?.VITE_ENABLE_API as string | undefined) === 'true';
+const ENABLE_API = ((import.meta as any).env?.VITE_ENABLE_API as string | undefined) !== 'false';
 // If no CoinGecko API key is provided, skip hitting CoinGecko entirely. This
 // avoids noisy 401 errors in development where the key is usually absent.
 const CG_KEY = (import.meta as any).env?.VITE_COINGECKO_API_KEY as string | undefined;


### PR DESCRIPTION
## Summary
- Default to using live price APIs unless explicitly disabled
- Document how to run the app offline with mock data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c05b0659c0832ca382a6b3e0e1e942